### PR TITLE
Add about page

### DIFF
--- a/lib/quke/demo_app/app.rb
+++ b/lib/quke/demo_app/app.rb
@@ -18,6 +18,11 @@ module Quke
         @title = "Welcome to Quke"
         erb :index
       end
+
+      get "/about" do
+        @title = "About"
+        erb :about
+      end
     end
   end
 end

--- a/lib/quke/demo_app/views/about.erb
+++ b/lib/quke/demo_app/views/about.erb
@@ -1,0 +1,2 @@
+<h1><%= @title %></h1>
+<p class="lead">The about page.</p>

--- a/spec/quke/demo_app/app_spec.rb
+++ b/spec/quke/demo_app/app_spec.rb
@@ -5,11 +5,32 @@ require "spec_helper"
 module Quke
   module DemoApp
     RSpec.describe App do
-      it "should allow accessing the home page" do
-        get "/"
+      context "/" do
+        it "GET displays the page" do
+          get "/"
 
-        expect(last_response).to be_ok
-        expect(last_response.body).to include("Welcome to Quke")
+          expect(last_response.body).to include("Welcome to Quke")
+        end
+
+        it "GET returns the status 200" do
+          get "/"
+
+          expect(last_response).to be_ok
+        end
+      end
+
+      context "/about" do
+        it "GET displays the page" do
+          get "/"
+
+          expect(last_response.body).to include("About")
+        end
+
+        it "GET returns the status 200" do
+          get "/"
+
+          expect(last_response).to be_ok
+        end
       end
     end
   end


### PR DESCRIPTION
Adds the about page to the demo site plus splits the unit tests so the check for a response and the check of the status code are distinct.