### PR TITLE
Add Javascript error page

### DIFF
--- a/lib/quke/demo_app/app.rb
+++ b/lib/quke/demo_app/app.rb
@@ -33,6 +33,13 @@ module Quke
         @title = "CSS selector"
         erb :css_selector
       end
+
+      get "/jserror" do
+        @title = "JavaScript error"
+        @results = "Open your browser's dev tools, specifically the JavaScript"\
+                   "console. You should see an error!"
+        erb :javascript_error
+      end
     end
   end
 end

--- a/lib/quke/demo_app/views/javascript_error.erb
+++ b/lib/quke/demo_app/views/javascript_error.erb
@@ -1,0 +1,19 @@
+    <!-- Main jumbotron for a primary marketing message or call to action -->
+    <div class="jumbotron">
+      <h1><%= @title %></h1>
+      <p class="lead">This page can be used for checking what happens when you test a page with a JavaScript error.</p>
+      <p class="lead">There are examples of how to test against the data in this page, but essentially they are just
+        using <strong>Capybara's</strong> <code>find()</code> method.</p>
+      <ul>
+        <li><code>features/quke/javascript_error.feature</code></li>
+        <li><code>features/step_definitions/quke/javascript_error_steps.rb</code></li>
+        <li><code>quke_demo_app/views/javascript_error.erb</code></li>
+      </ul>
+    </div>
+    <script>
+      throw ({'error':'boom'});
+    </script>
+    <div id="result">
+      <h2>Results</h2>
+      <p><%= @results %></p>
+    </div>

--- a/spec/quke/demo_app/app_spec.rb
+++ b/spec/quke/demo_app/app_spec.rb
@@ -60,6 +60,20 @@ module Quke
           expect(last_response).to be_ok
         end
       end
+
+      context "/jserror" do
+        it "GET displays the page" do
+          get "/jserror"
+
+          expect(last_response.body).to include("page with a JavaScript error")
+        end
+
+        it "GET returns the status 200" do
+          get "/jserror"
+
+          expect(last_response).to be_ok
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This page generates a javascript error on purpose to allow [quke-example](https://github.com/DEFRA/quke-example) to demonstrate how you can use [Quke](https://quke.com/DEFRA/quke) and [Capybara](https://github.com/teamcapybara/capybara) to check for them.