### PR TITLE
Add request details page

### DIFF
--- a/lib/quke/demo_app/app.rb
+++ b/lib/quke/demo_app/app.rb
@@ -40,6 +40,12 @@ module Quke
                    "console. You should see an error!"
         erb :javascript_error
       end
+
+      get "/request" do
+        @title = "Request details"
+        @results = request.env
+        erb :request
+      end
     end
   end
 end

--- a/lib/quke/demo_app/views/request.erb
+++ b/lib/quke/demo_app/views/request.erb
@@ -1,0 +1,20 @@
+    <!-- Main jumbotron for a primary marketing message or call to action -->
+    <div class="jumbotron">
+      <h1><%= @title %></h1>
+      <p class="lead">This page can be used for checking that the request you formulated in <strong>Quke</strong> is as
+        expected. It will display the details for each item in the request.</p>
+      <p class="lead">There are examples of how to test against the data in this page, but essentially they are just
+        using <strong>Capybara's</strong> <code>find()</code> method.</p>
+      <ul>
+        <li><code>features/quke/request_details.feature</code></li>
+        <li><code>features/step_definitions/quke/request_details_steps.rb</code></li>
+        <li><code>quke_demo_app/views/request_details.erb</code></li>
+      </ul>
+    </div>
+
+    <div id="results">
+      <h2>Results</h2>
+      <% @results.each do | key, value | %>
+        <div><strong><%= key %></strong> <code id="<%= key %>"><%= value %></code></div>
+      <% end %>
+    </div>

--- a/spec/quke/demo_app/app_spec.rb
+++ b/spec/quke/demo_app/app_spec.rb
@@ -74,6 +74,20 @@ module Quke
           expect(last_response).to be_ok
         end
       end
+
+      context "/request" do
+        it "GET displays the page" do
+          get "/request"
+
+          expect(last_response.body).to include("checking that the request")
+        end
+
+        it "GET returns the status 200" do
+          get "/request"
+
+          expect(last_response).to be_ok
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This page can be used for checking that the request you formulated in a [Quke](https://github.com/DEFRA/quke) is as expected. It will display the details for each item in the GET request received.