### PR TITLE
Add radio button page

### DIFF
--- a/lib/quke/demo_app/app.rb
+++ b/lib/quke/demo_app/app.rb
@@ -41,6 +41,19 @@ module Quke
         erb :javascript_error
       end
 
+      get "/radiobutton" do
+        @title = "Radio button"
+        erb :radio_button
+      end
+
+      post "/radiobutton" do
+        @title = "Radio button"
+        @selection = params["enrollment"]["organisation_attributes"]["type"]
+        @result = @selection.match(/OrganisationType::([^"]*)/)[1]
+
+        erb :radio_button
+      end
+
       get "/request" do
         @title = "Request details"
         @results = request.env

--- a/lib/quke/demo_app/views/radio_button.erb
+++ b/lib/quke/demo_app/views/radio_button.erb
@@ -1,0 +1,55 @@
+      <!-- Main jumbotron for a primary marketing message or call to action -->
+      <div class="jumbotron">
+        <h1><%= @title %></h1>
+        <p class="lead">Tests for this page are all about working with collections of elements like radio buttons.
+          The steps behind <code>radio_button.feature</code> show getting a collection of linked elements, checking
+          you have the right number, and for something like a radio button how to select a specific one.</p>
+        <p class="lead">Though the examples are for radio buttons, the same selecting and checking logic can be
+          used with any elements e.g. <code>&lt;div&gt;</code>, <code>&lt;a&gt;</code>, <code>&lt;tr&gt;</code>.
+          It just comes down to the CSS selector you use. See the following for details</p>
+        <ul>
+          <li><code>features/quke/radio_button.feature</code></li>
+          <li><code>features/step_definitions/quke/radio_button_steps.rb</code></li>
+          <li><code>quke_demo_app/views/radio_button.erb</code></li>
+        </ul>
+      </div>
+
+      <form id="radio_button_example" action="/radiobutton" accept-charset="UTF-8" method="post">
+        <fieldset>
+
+          <div id="form_group_organisation_type" role="group" aria-labelledby="groupLabel" class="form">
+            <label class="radio" for="organisation_limited_company">
+              <input id="organisation_limited_company" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedCompany" name="enrollment[organisation_attributes][type]" />
+              Limited company
+            </label>
+            <label class="radio" for="organisation_limited_liability_partnership">
+              <input id="organisation_limited_liability_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::LimitedLiabilityPartnership" name="enrollment[organisation_attributes][type]" />
+              Limited liability partnership
+            </label>
+            <label class="radio" for="organisation_partnership">
+              <input id="organisation_partnership" type="radio" value="WasteExemptionsShared::OrganisationType::Partnership" name="enrollment[organisation_attributes][type]" />
+              Partnership
+            </label>
+            <label class="radio" for="organisation_other">
+              <input id="organisation_other" type="radio" value="WasteExemptionsShared::OrganisationType::Other" name="enrollment[organisation_attributes][type]" />
+              Other (trust, club or public body)
+            </label>
+            <label class="radio" for="organisation_not_known">
+              <input id="organisation_not_known" type="radio" value="WasteExemptionsShared::OrganisationType::NotKnown" name="enrollment[organisation_attributes][type]" />
+              I don’t know
+            </label>
+          </div>
+        </fieldset>
+
+        <div class="actions">
+          <input type="submit" id="commit" name="commit" value="Continue" class="button"/>
+        </div>
+      </form>
+      <% if @result %>
+      <div id="results">
+        <h2>Results</h2>
+        <div id="selected-option" class="result">
+          <p class="result-desc"><span id="result">You selected <strong><%= @result %></strong></span></p>
+        </div>
+      </div>
+      <% end %>

--- a/spec/quke/demo_app/app_spec.rb
+++ b/spec/quke/demo_app/app_spec.rb
@@ -88,6 +88,32 @@ module Quke
           expect(last_response).to be_ok
         end
       end
+
+      context "/radiobutton" do
+        it "GET displays the page" do
+          get "/radiobutton"
+
+          expect(last_response.body).to include("elements like radio buttons")
+        end
+
+        it "GET returns the status 200" do
+          get "/radiobutton"
+
+          expect(last_response).to be_ok
+        end
+
+        it "POST to the page displays selected option" do
+          post "/radiobutton", "enrollment[organisation_attributes][type]=WasteExemptionsShared::OrganisationType::Partnership"
+
+          expect(last_response.body).to include("You selected <strong>Partnership</strong>")
+        end
+
+        it "POST returns the status 200" do
+          post "/radiobutton", "enrollment[organisation_attributes][type]=WasteExemptionsShared::OrganisationType::Partnership"
+
+          expect(last_response).to be_ok
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This page is used for tests that are all about working with collections of elements like radio buttons.

[quke-example](https://github.com/DEFRA/quke-example) relies on this page to demonstrate a feature that shows getting a collection of linked elements, checking you have the right number, and for something like a radio button how to select a specific one.