### PR TITLE
Move Runner to DemoApp and fix exe

### DIFF
--- a/exe/quke_demo_app
+++ b/exe/quke_demo_app
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "quke"
+require_relative "../lib/quke/demo_app"
 
-Quke::Runner.run(ARGV)
+Quke::DemoApp::Runner.run(ARGV)

--- a/lib/quke.rb
+++ b/lib/quke.rb
@@ -3,10 +3,5 @@
 require "quke/demo_app"
 
 module Quke
-  class Runner
-    def self.run(_args = [])
-      puts "Hello, you're running your web app from a gem!"
-      Quke::DemoApp::App.run!
-    end
-  end
+
 end

--- a/lib/quke/demo_app.rb
+++ b/lib/quke/demo_app.rb
@@ -6,5 +6,11 @@ require_relative "demo_app/app"
 module Quke
   module DemoApp
     # The DemoApp namespace
+    class Runner
+      def self.run(_args = [])
+        puts "Hello, you're running your web app from a gem!"
+        Quke::DemoApp::App.run!
+      end
+    end
   end
 end


### PR DESCRIPTION
It didn't seem right having the `Runner` for the demo app in the root `Quke` module so this change moves it to the `DemoApp` module.

Also we found that running `exe/quke_demo_app` was throwing an error. A bit of digging and it seems it

- didn't like our require of Quke, particularly when run from [quke-example](https://github.com/DEFRA/quke-example)
- would error complaining it didn't know what `DemoApp` was

So we also ensured that we could start the app directly using `exe/quke_demo_app` and from **quke-exemple**.