### PR TITLE
Update project to be Defra standards compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=d6ed9ffedf497bc2107866f279b5b89536a4096b3e3fa5432b7fdb8a027da0c3
+
+language: ruby
+rvm: 2.4.2
+cache: bundler
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
+
+before_script:
+  # Setup to support the CodeClimate test coverage submission
+  # As per CodeClimate's documentation, they suggest only running
+  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
+  # the codeclimate test coverage related commands in a check that tests if we
+  # are in a pull request or not.
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
+  # Run rubocop. It's installed as a dependency (hence no install step) as this
+  # allows projects to control the version they are using (rather than getting)
+  # surprise build failures.
+  - bundle exec rubocop
+
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in quke-demo-app.gemspec
 gemspec

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,8 @@
-The MIT License (MIT)
+The Open Government Licence (OGL) Version 3
 
-Copyright (c) 2019 Alan Cruikshanks
+Copyright (c) 2019 Defra
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Quke demo app
 
-A Sinatra web app packaged as a gem that is used to demonstrate https://github/DEFRA/quke
+[![Build Status](https://travis-ci.com/DEFRA/quke-demo-app.svg?branch=master)](https://travis-ci.com/DEFRA/quke-demo-app)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d0ca26293d6b7bfd1b8b/maintainability)](https://codeclimate.com/github/DEFRA/quke-demo-app/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/d0ca26293d6b7bfd1b8b/test_coverage)](https://codeclimate.com/github/DEFRA/quke-demo-app/test_coverage)
+[![security](https://hakiri.io/github/DEFRA/quke-demo-app/master.svg)](https://hakiri.io/github/DEFRA/quke-demo-app/master)
+[![Gem Version](https://badge.fury.io/rb/quke_demo_app.svg)](https://badge.fury.io/rb/quke_demo_app)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
+
+A Sinatra web app packaged as a gem that is used to demonstrate <https://github/DEFRA/quke>
 
 ## Installating the app
 
@@ -10,13 +17,7 @@ Add this line to your application's Gemfile
 gem 'quke_demo_app'
 ```
 
-And then execute:
-
-```shell
-bundle
-```
-
-Or install it yourself as:
+Or install it yourself as
 
 ```shell
 gem install quke-demo-app
@@ -44,12 +45,24 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
-## Contributing
+## Contributing to this project
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/Cruikshanks/quke-demo-app.
+If you have an idea you'd like to contribute please log an issue.
+
+All contributions should be submitted via a pull request.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
-> If you don't add a license it's neither free or open!
+<http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+> Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,69 @@
+# Releasing
+
+As the gem is a dependency in a number of services we build and deploy it to [Rubygems](https://rubygems.org/gems/defra_ruby_aws) so we can properly version it, and the dependent services can manage which versions they take.
+
+This means as changes are made, we will also need to update the version of the gem published to Rubygems. The following outlines the steps to take.
+
+## Decide on the version
+
+Assuming changes have been made to the project, the first step is deciding when to cut a new release. This will determine the version number assigned because as best as we can, we try to follow [Semver](https://semver.org/).
+
+Essentially
+
+- breaking changes to the API should result in a **MAJOR** version change
+- adding new functionality, major changes to dependencies, or large scale housekeeping overhauls should result in a **MINOR** version change
+- fixes, minor changes to dependencies, and minor housekeeping tasks should result in a **PATCH** version change
+
+## Update version.rb
+
+Update `lib/quke/demo_app/version.rb` to match the version number you intend to release with.
+
+```ruby
+module Quke
+  module DemoApp
+    VERSION = "0.1.0"
+  end
+end
+```
+
+Commit the change and push to **master**. We don't create a PR for this as we rely on PR's to provide the content for our [CHANGELOG](CHANGELOG.md), so this would just make for a redundant entry.
+
+## Tag the repo
+
+Assuming that has built successfully in Travis, then tag the repo and push the new tag
+
+```bash
+git tag -a v0.1.0 -m "Version 0.1.0"
+git push origin v0.1.0
+```
+
+[Travis-CI](https://travis-ci.com/DEFRA/quke-demo-app) is automatically configured to build and deploy the updated gem to Rubygems when it sees a new tag pushed. It will only succeed though if the new version does not match one that has already been published to Rubygems.
+
+Hence it's important to update the `version.rb` before creating and pushing the new tag.
+
+## Update CHANGELOG
+
+With the new version published we can update the [CHANGELOG](CHANGELOG.md). This is automatically done via a rake task.
+
+```bash
+bundle exec rake changelog
+```
+
+Commit the changes to `CHANGELOG.md` and push to **master**. Again like the version change we don't create a PR for this as we don't want PR's for updating the CHANGELOG becoming noise in its content.
+
+## Publish release
+
+In GitHub select the releases page for the project, then click 'Draft a new release'. Select the version tag we've just released, leave target as master, and set the release title as **Version #.#.#**. In the description simply copy the content from the CHANGELOG for the release.
+
+```markdown
+# v0.1.0 (2019-04-03)
+
+[Full changelog](https://github.com/DEFRA/quke-demo-app/blob/master/CHANGELOG.md#v010-2019-01-25)
+
+## Merged pull requests:
+
+- Add CLI support to the project #12 (Cruikshanks)
+- Move Runner to DemoApp and fix exe #11 (Cruikshanks)
+```
+
+Save the changes and you're done.

--- a/exe/quke_demo_app
+++ b/exe/quke_demo_app
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# frozen_string_literal: true
+
 # When testing with Aruba we are actually running the gem under a separate
 # process. This means though we are running a test that is exercising our code
 # simplecov doesn't see it.

--- a/quke_demo_app.gemspec
+++ b/quke_demo_app.gemspec
@@ -7,10 +7,10 @@ require "quke/demo_app/version"
 Gem::Specification.new do |spec|
   spec.name          = "quke_demo_app"
   spec.version       = Quke::DemoApp::VERSION
-  spec.authors       = ["Alan Cruikshanks"]
-  spec.email         = ["alan.cruikshanks@gmail.com"]
-  spec.license       = "MIT"
-  spec.homepage      = "https://github.com/Cruikshanks/quke-demo-app"
+  spec.authors       = ["Defra"]
+  spec.email         = ["alan.cruikshanks@environment-agency.gov.uk"]
+  spec.license       = "The Open Government Licence (OGL) Version 3"
+  spec.homepage      = "https://github.com/DEFRA/quke-demo-app"
   spec.summary       = "A web app used to demo Quke functionality."
   spec.description   = "A Sinatra web app packaged as a gem that is used to demonstrate https://github/DEFRA/quke"
 


### PR DESCRIPTION
As part of moving the project into the Defra organisation there are some things we neded to update

- license moving to OGL V3
- contribution and license details at end of README
- integration with Travis-CI, CodeClimate, Hakiri and Dependabot
- any organisation details