### PR TITLE
Resolve Hakiri warning for Sinatra version

### DIFF
--- a/quke_demo_app.gemspec
+++ b/quke_demo_app.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
 
   # Sinatra is a DSL for quickly creating web applications in Ruby with minimal
   # effort. We've used it for creating our demo website
-  spec.add_dependency "sinatra"
+  spec.add_dependency "sinatra", "~> 2.0.2"
   # Thor is a toolkit for building powerful command-line interfaces.
   spec.add_dependency "thor"
 


### PR DESCRIPTION
Because in the previous version of the gemspec we had an open reference to Sinatra it meant we were essentially saying any version would do.

Hakiri was flagging this with [CVE-2018-7212](https://github.com/sinatra/sinatra/pull/1379), the resolution of which was to specify a version equal to or greater than 2.0.1