### PR TITLE
Fix rubocop issue

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -31,4 +31,4 @@ begin
 rescue LoadError
   # no changelog available
 end
-# rubocop:enable Lint/HandleExceptions
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
The latest version of rubocop has changed the namespace for suppressing exceptions. This resolves the issue and prevents rubocop raising

```bash
Inspecting 18 files
.W................

Offenses:

Rakefile:15:1: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/HandleExceptions (unknown cop).
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Rakefile:22:1: W: Lint/SuppressedException: Do not suppress exceptions. (https://rubystyle.guide#dont-hide-exceptions)
rescue LoadError
^^^^^^^^^^^^^^^^
Rakefile:31:1: W: Lint/SuppressedException: Do not suppress exceptions. (https://rubystyle.guide#dont-hide-exceptions)
rescue LoadError
^^^^^^^^^^^^^^^^

18 files inspected, 3 offenses detected
```