### PR TITLE
Temp. fix for cc-test-reporter & SimpleCov 0.18

### DIFF
--- a/quke_demo_app.gemspec
+++ b/quke_demo_app.gemspec
@@ -64,5 +64,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0.17.1"
 end


### PR DESCRIPTION
https://github.com/codeclimate/test-reporter/issues/418

On 28 Jan 2020 [SimpleCov 0.18.0](https://github.com/colszowka/simplecov/releases/tag/v0.18.0) was released. Though it's generating code coverage for us, its changed the JSON format of the `/coverage/.resultset.json` CodeClimate's [cc-test-reporter](https://github.com/codeclimate/test-reporter) appears to rely on.

<details>
  <summary>Format before</summary>

  ```json
  {
    "RSpec": {
      "coverage": {
        "/path/to/my/file.rb": [
          null,
          null,
          1
        ]
      },
      "timestamp": 1580226312
    }
  }
  ```
</details>

<details>
  <summary>Format after</summary>

  ```json
  {
    "RSpec": {
      "coverage": {
        "/path/to/my/file.rb": {
          "lines": [
            null,
            null,
            1,
            null
          ],
          "branches": {
          }
        }
      },
      "timestamp": 1580299988
    }
  }
  ```
</details>

When **cc-test-reporter** is called in the `after_script` hook in Travis-CI we are seeing the following error

```bash
if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
Error: json: cannot unmarshal object into Go struct field input.coverage of type []formatters.NullInt
Usage:
  cc-test-reporter after-build [flags]
Flags:
  -s, --batch-size int               batch size for source files (default 500)
  -e, --coverage-endpoint string     endpoint to upload coverage information to (default "https://api.codeclimate.com/v1/test_reports")
  -t, --coverage-input-type string   type of input source to use [clover, cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov, simplecov, xccov]
      --exit-code int                exit code of the test run
  -r, --id string                    reporter identifier (default "463a251defaae85271bff85ea8b1e58aa06cc9322157aa3ad7ee2a986aa13612")
      --insecure                     send coverage insecurely (without HTTPS)
  -p, --prefix string                the root directory where the coverage analysis was performed (default "/home/travis/build/DEFRA/waste-carriers-front-office")
Global Flags:
  -d, --debug   run in debug mode
```

As the CodeClimate integration is important to our CI process, we have chosen to temporarily set the version of SimpleCov as 0.17.1 until the issue is resolved.