### PR TITLE
Fix rubocop: Unnecessary disabling of exception

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,6 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -31,4 +30,3 @@ begin
 rescue LoadError
   # no changelog available
 end
-# rubocop:enable Lint/SuppressedException

--- a/quke_demo_app.gemspec
+++ b/quke_demo_app.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.bindir        = "exe"
   spec.executables   = ["quke_demo_app"]
-  spec.default_executable = "quke_demo_app"
 
   # Sinatra is a DSL for quickly creating web applications in Ruby with minimal
   # effort. We've used it for creating our demo website


### PR DESCRIPTION
Fixes

```bash
Offenses:

Rakefile:15:1: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/SuppressedException.
```

The change also fixes this warning.

```bash
NOTE: Gem::Specification#default_executable= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#default_executable= called from /Users/acruikshanks/projects/defra/quke-demo-app/quke_demo_app.gemspec:37.
```