### PR TITLE
Fix Aruba specs failing

### DIFF
--- a/spec/quke_demo_app/cli_spec.rb
+++ b/spec/quke_demo_app/cli_spec.rb
@@ -16,7 +16,7 @@ module QukeDemoApp
         # set_environment_variable() is a method provided by Aruba, as is
         # run_command
         set_environment_variable("COVERAGE", "true")
-        run_command("exe/quke_demo_app #{port_args}")
+        run_command("quke_demo_app #{port_args}")
       end
 
       it { expect(last_command_started).to be_successfully_executed }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "aruba/rspec"
 
 # Require and run our simplecov initializer as the very first thing we do.
 # This is as per its docs https://github.com/colszowka/simplecov#getting-started


### PR DESCRIPTION
At the beginning of the year we spotted the Aruba based specs of the CLI were failing.

Errors were like the following

```bash
1) QukeDemoApp::Cli Start the demo app
     Failure/Error: run_command("exe/quke_demo_app #{port_args}")

     Aruba::LaunchError:
       Command "exe/quke_demo_app" not found in PATH-variable "/Users/acruikshanks/projects/defra/quke-demo-app/bin:/Users/acruikshanks/projects/defra/quke-demo-app/exe:/Users/acruikshanks/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/bin:/Users/acruikshanks/.rbenv/versions/2.4.2/bin:/usr/local/Cellar/rbenv/1.1.2/libexec:/Users/acruikshanks/go/bin:/Users/acruikshanks/.pyenv/shims:/Users/acruikshanks/.rbenv/shims:/Users/acruikshanks/.jenv/shims:/Users/acruikshanks/.nvm/versions/node/v14.2.0/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin".
     # ./spec/quke_demo_app/cli_spec.rb:19:in `block (3 levels) in <module:QukeDemoApp>'
```

After some Googling we found this [stackoverflow post](https://stackoverflow.com/a/55323432/6117745). We were already doing what it suggests but we followed the link provided to the [example commit mentioned](https://github.com/lacostenycoder/simple-aruby-specs/commit/0a9de68262cfb5425f0c9c7b4990cf07e302e871). A comparison found we

- were not requiring `aruba/rspec`
- were calling `run_command()` differently

So with the following changes we were able to get everything running again.