### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,27 @@
-env:
-  global:
-  - CC_TEST_REPORTER_ID=d6ed9ffedf497bc2107866f279b5b89536a4096b3e3fa5432b7fdb8a027da0c3
+dist: trusty
+
+addons:
+  sonarcloud:
+    organization: "defra"
 
 language: ruby
 rvm: 2.4.2
 cache: bundler
 
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
 git:
-  depth: 3
+  depth: false
 
 before_install:
-- export TZ=UTC
-- gem install -v 1.17.2 bundler --no-rdoc --no-ri
+  - export TZ=UTC
+  - gem install -v 1.17.3 bundler --no-document
 
-before_script:
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-  > ./cc-test-reporter; fi
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build;
-  fi
-- bundle exec rubocop
-after_script:
-- if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code
-  $TRAVIS_TEST_RESULT; fi
+script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rspec
+  - sonar-scanner
 
 deploy:
   provider: rubygems

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Quke demo app
 
 [![Build Status](https://travis-ci.com/DEFRA/quke-demo-app.svg?branch=master)](https://travis-ci.com/DEFRA/quke-demo-app)
-[![Maintainability](https://api.codeclimate.com/v1/badges/d0ca26293d6b7bfd1b8b/maintainability)](https://codeclimate.com/github/DEFRA/quke-demo-app/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/d0ca26293d6b7bfd1b8b/test_coverage)](https://codeclimate.com/github/DEFRA/quke-demo-app/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_quke-demo-app&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_quke-demo-app)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_quke-demo-app&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_quke-demo-app)
 [![security](https://hakiri.io/github/DEFRA/quke-demo-app/master.svg)](https://hakiri.io/github/DEFRA/quke-demo-app/master)
 [![Gem Version](https://badge.fury.io/rb/quke_demo_app.svg)](https://badge.fury.io/rb/quke_demo_app)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,30 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_quke-demo-app
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=quke-demo-app
+sonar.projectVersion=0.2.0
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/quke-demo-app
+sonar.links.ci=https://travis-ci.com/DEFRA/quke-demo-app
+sonar.links.scm=https://github.com/DEFRA/quke-demo-app
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We used to use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. Then a number of Defra projects started using an internal SonarQube instance, and some public ones used SonarCloud (the cloud SASS version of SonarQube).

We've since adopted SonarCloud formerly and all projects will coalesce onto. This is the last of our repos to switch across to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318