### PR TITLE
Fix rubocop issue

### DIFF
--- a/quke_demo_app.gemspec
+++ b/quke_demo_app.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
+  spec.required_ruby_version = ">= 2.4"
+
   spec.bindir        = "exe"
   spec.executables   = ["quke_demo_app"]
 


### PR DESCRIPTION
The latest rubocop is finding an issue which is breaking the build. This change fixes it.